### PR TITLE
Changes for autocomplete in IDE

### DIFF
--- a/src/Expression.php
+++ b/src/Expression.php
@@ -33,7 +33,10 @@ class Expression implements Arrayable
     {
         return new self;
     }
-
+    /**
+     * Return a expression
+     * @return \Sokil\Mongo\Cursor|\Sokil\Mongo\Expression
+     */
     public function where($field, $value)
     {
         if(!isset($this->_expression[$field]) || !is_array($value) || !is_array($this->_expression[$field])) {


### PR DESCRIPTION
    ->where('name', 'Michael')
    ->whereGreater('age', 29)
    ->whereIn('interests', ['php', 'snowboard', 'traveling'])
    ->skip(20)

"Skip" not highlighted with autocomplete.
That is fix it