### PR TITLE
support empty plain object as value

### DIFF
--- a/src/Structure.php
+++ b/src/Structure.php
@@ -360,6 +360,10 @@ class Structure implements
             return $value->toArray();
         }
 
+        if ($value instanceof \stdClass) {
+            return $value;   
+        }
+
         // other objects convert to array
         return (array) $value;
     }


### PR DESCRIPTION
more information you can find here https://jira.mongodb.org/browse/PHP-172

sometimes you need save empty plain object {} as value

```php
$document->set('myValue', new stdClass);
```

result:
```
{
  myValue: {}
}
```

but now it always saved as ↓, because value casts to array

```
{
  myValue: []
}
```