### PR TITLE
bug/DatabaseCreateCollection error while calling Database::createColl…

### DIFF
--- a/src/Database.php
+++ b/src/Database.php
@@ -282,7 +282,7 @@ class Database
      * @return \Sokil\Mongo\Collection
      * @throws \Sokil\Mongo\Exception
      */
-    public function createCollection($name, array $options = null)
+    public function createCollection($name, array $options = [])
     {
         $classDefinition = $this->getCollectionDefinition($name);
         $classDefinition->merge($options);


### PR DESCRIPTION
…ection with just one param, because classDefinition::merge inside expects array, not null variable