### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "symfony/polyfill-php55": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=3.7.38 <6.0",
+        "phpunit/phpunit": ">=4.8.35 <6.0",
         "satooshi/php-coveralls": ">=0.7.1 <2.0",
         "squizlabs/php_codesniffer": "^2.3",
         "phpmd/phpmd" : "@stable"

--- a/tests/AggregatePipelineTest.php
+++ b/tests/AggregatePipelineTest.php
@@ -3,8 +3,9 @@
 namespace Sokil\Mongo;
 
 use Sokil\Mongo\Expression;
+use PHPUnit\Framework\TestCase;
 
-class AggregatePipelinesTest extends \PHPUnit_Framework_TestCase
+class AggregatePipelinesTest extends TestCase
 {
     /**
      *

--- a/tests/BatchInsertTest.php
+++ b/tests/BatchInsertTest.php
@@ -2,7 +2,9 @@
 
 namespace Sokil\Mongo;
 
-class BatchInsertTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class BatchInsertTest extends TestCase
 {
     /**
      *

--- a/tests/BatchTest.php
+++ b/tests/BatchTest.php
@@ -2,7 +2,9 @@
 
 namespace Sokil\Mongo;
 
-class BatchTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class BatchTest extends TestCase
 {
     /**
      *

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -2,7 +2,9 @@
 
 namespace Sokil\Mongo;
 
-class CacheTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class CacheTest extends TestCase
 {    
     /**
      *

--- a/tests/ClientPoolTest.php
+++ b/tests/ClientPoolTest.php
@@ -2,7 +2,9 @@
 
 namespace Sokil\Mongo;
 
-class ClientPoolTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ClientPoolTest extends TestCase
 {
     
     public function testGet()

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -2,7 +2,9 @@
 
 namespace Sokil\Mongo;
 
-class ClientTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ClientTest extends TestCase
 {
     /**
      *

--- a/tests/CollectionLockTest.php
+++ b/tests/CollectionLockTest.php
@@ -6,8 +6,9 @@ use Sokil\Mongo\Client;
 use Sokil\Mongo\Collection\Definition;
 use Sokil\Mongo\Document\OptimisticLockFailureException;
 use Sokil\Mongo\Document\PessimisticLockFailureException;
+use PHPUnit\Framework\TestCase;
 
-class CollectionLockTest extends \PHPUnit_Framework_TestCase
+class CollectionLockTest extends TestCase
 {
     public function testLockConfiguration()
     {

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -2,7 +2,9 @@
 
 namespace Sokil\Mongo;
 
-class CollectionTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class CollectionTest extends TestCase
 {
     /**
      *

--- a/tests/CursorTest.php
+++ b/tests/CursorTest.php
@@ -2,7 +2,9 @@
 
 namespace Sokil\Mongo;
 
-class CursorTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class CursorTest extends TestCase
 {
     /**
      *

--- a/tests/DatabaseTest.php
+++ b/tests/DatabaseTest.php
@@ -2,7 +2,9 @@
 
 namespace Sokil\Mongo;
 
-class DatabaseTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class DatabaseTest extends TestCase
 {
     /**
      *

--- a/tests/DocumentAddToSetTest.php
+++ b/tests/DocumentAddToSetTest.php
@@ -3,8 +3,9 @@
 namespace Sokil\Mongo;
 
 use Sokil\Mongo\Document\InvalidOperationException;
+use PHPUnit\Framework\TestCase;
 
-class DocumentAddToSetTest extends \PHPUnit_Framework_TestCase
+class DocumentAddToSetTest extends TestCase
 {
     /**
      *

--- a/tests/DocumentBehaviorTest.php
+++ b/tests/DocumentBehaviorTest.php
@@ -2,7 +2,9 @@
 
 namespace Sokil\Mongo;
 
-class DocumentBehaviorTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class DocumentBehaviorTest extends TestCase
 {
     /**
      *

--- a/tests/DocumentEventTest.php
+++ b/tests/DocumentEventTest.php
@@ -18,8 +18,9 @@ class DocumentWithAfterConstructEvent extends Document
         });
     }
 }
+use PHPUnit\Framework\TestCase;
 
-class DocumentEventTest extends \PHPUnit_Framework_TestCase
+class DocumentEventTest extends TestCase
 {
     /**
      *

--- a/tests/DocumentGeoTest.php
+++ b/tests/DocumentGeoTest.php
@@ -2,10 +2,12 @@
 
 namespace Sokil\Mongo;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @link http://docs.mongodb.org/manual/core/2dsphere/
  */
-class DocumentGeoTest extends \PHPUnit_Framework_TestCase
+class DocumentGeoTest extends TestCase
 {
     /**
      *

--- a/tests/DocumentMergeTest.php
+++ b/tests/DocumentMergeTest.php
@@ -2,7 +2,9 @@
 
 namespace Sokil\Mongo;
 
-class DocumentMergeTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class DocumentMergeTest extends TestCase
 {
     /**
      *

--- a/tests/DocumentPushTest.php
+++ b/tests/DocumentPushTest.php
@@ -3,8 +3,9 @@
 namespace Sokil\Mongo;
 
 use Sokil\Mongo\Document\InvalidOperationException;
+use PHPUnit\Framework\TestCase;
 
-class DocumentPushTest extends \PHPUnit_Framework_TestCase
+class DocumentPushTest extends TestCase
 {
     const FIELD_NAME_NEW = 'new';
     const FIELD_NAME_SCALAR = 'scalar';

--- a/tests/DocumentRelationTest.php
+++ b/tests/DocumentRelationTest.php
@@ -2,7 +2,9 @@
 
 namespace Sokil\Mongo;
 
-class DocumentRelationTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class DocumentRelationTest extends TestCase
 {
     private $database;
     

--- a/tests/DocumentTest.php
+++ b/tests/DocumentTest.php
@@ -4,8 +4,9 @@ namespace Sokil\Mongo;
 
 use Sokil\Mongo\DocumentTest\DeprecatedSchemaDocumentStub;
 use Sokil\Mongo\DocumentTest\DocumentStub;
+use PHPUnit\Framework\TestCase;
 
-class DocumentTest extends \PHPUnit_Framework_TestCase
+class DocumentTest extends TestCase
 {
     /**
      *

--- a/tests/DocumentValidationTest.php
+++ b/tests/DocumentValidationTest.php
@@ -3,8 +3,9 @@
 namespace Sokil\Mongo;
 
 use Sokil\Mongo\DocumentValidationTest\ValidatorMethodDocument;
+use PHPUnit\Framework\TestCase;
 
-class DocumentValidationTest extends \PHPUnit_Framework_TestCase
+class DocumentValidationTest extends TestCase
 {
     /**
      *

--- a/tests/DocumentVersioningTest.php
+++ b/tests/DocumentVersioningTest.php
@@ -2,7 +2,9 @@
 
 namespace Sokil\Mongo;
 
-class DocumentVersioningTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class DocumentVersioningTest extends TestCase
 {
     private $collection;
     

--- a/tests/EmbeddedDocumentTest.php
+++ b/tests/EmbeddedDocumentTest.php
@@ -4,8 +4,9 @@ namespace Sokil\Mongo;
 
 use Sokil\Mongo\Document\InvalidDocumentException;
 use Sokil\Mongo\EmbeddedDocumentTest\ProfileDocument;
+use PHPUnit\Framework\TestCase;
 
-class EmbeddedDocumentTest extends \PHPUnit_Framework_TestCase
+class EmbeddedDocumentTest extends TestCase
 {
     /**
      *

--- a/tests/ExpressionTest.php
+++ b/tests/ExpressionTest.php
@@ -2,7 +2,9 @@
 
 namespace Sokil\Mongo;
 
-class ExpressionTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ExpressionTest extends TestCase
 {
     /**
      * @var Collection

--- a/tests/GridFsFileTest.php
+++ b/tests/GridFsFileTest.php
@@ -2,7 +2,9 @@
 
 namespace Sokil\Mongo;
 
-class GridFsFileTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class GridFsFileTest extends TestCase
 {
     /**
      *

--- a/tests/GridFsTest.php
+++ b/tests/GridFsTest.php
@@ -2,7 +2,9 @@
 
 namespace Sokil\Mongo;
 
-class GridFsTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class GridFsTest extends TestCase
 {
     /**
      *

--- a/tests/OperatorTest.php
+++ b/tests/OperatorTest.php
@@ -2,7 +2,9 @@
 
 namespace Sokil\Mongo;
 
-class OperatorTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class OperatorTest extends TestCase
 {
     public function testSet()
     {

--- a/tests/PaginatorTest.php
+++ b/tests/PaginatorTest.php
@@ -2,7 +2,9 @@
 
 namespace Sokil\Mongo;
 
-class PaginatorTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class PaginatorTest extends TestCase
 {
     /**
      *

--- a/tests/PersistenceTest.php
+++ b/tests/PersistenceTest.php
@@ -2,7 +2,9 @@
 
 namespace Sokil\Mongo;
 
-class PersistenceTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class PersistenceTest extends TestCase
 {    
     /**
      *

--- a/tests/Pipeline/ExpressionTest.php
+++ b/tests/Pipeline/ExpressionTest.php
@@ -4,8 +4,9 @@ namespace Sokil\Mongo\Pipeline;
 
 use Sokil\Mongo\Client;
 use Sokil\Mongo\Pipeline;
+use PHPUnit\Framework\TestCase;
 
-class ExpressionTest extends \PHPUnit_Framework_TestCase
+class ExpressionTest extends TestCase
 {
     /**
      *

--- a/tests/Pipeline/GroupStageTest.php
+++ b/tests/Pipeline/GroupStageTest.php
@@ -4,8 +4,9 @@ namespace Sokil\Mongo\Pipeline;
 
 use Sokil\Mongo\Client;
 use Sokil\Mongo\Pipeline;
+use PHPUnit\Framework\TestCase;
 
-class GroupStageTest extends \PHPUnit_Framework_TestCase
+class GroupStageTest extends TestCase
 {
     /**
      *

--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -2,7 +2,9 @@
 
 namespace Sokil\Mongo;
 
-class QueueTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class QueueTest extends TestCase
 {
     /**
      *

--- a/tests/ResultSetTest.php
+++ b/tests/ResultSetTest.php
@@ -2,7 +2,9 @@
 
 namespace Sokil\Mongo;
 
-class ResultSetTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ResultSetTest extends TestCase
 {
     public function testMap()
     {

--- a/tests/StructureTest.php
+++ b/tests/StructureTest.php
@@ -2,7 +2,9 @@
 
 namespace Sokil\Mongo;
 
-class StructureTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class StructureTest extends TestCase
 {
     public function testSet()
     {


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`>=4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.