### PR TITLE
Add support set in fields stdClass in Structure::prepareToStore

### DIFF
--- a/src/Structure.php
+++ b/src/Structure.php
@@ -399,6 +399,11 @@ class Structure implements
             return $value->toArray();
         }
 
+        // stdClass
+        if ($value instanceof \stdClass) {
+            return $value;
+        }
+
         // other objects convert to array
         return (array) $value;
     }

--- a/tests/DocumentAddToSetTest.php
+++ b/tests/DocumentAddToSetTest.php
@@ -46,7 +46,7 @@ class DocumentAddToSetTest extends TestCase
                 null, 'string1', 'string2', array('string1', 'string2'),
             ),
             'newField_emptyStdclass' => array(
-                null, $stdClass, $stdClass, array(array()),
+                null, $stdClass, $stdClass, array($stdClass),
             ),
             'newField_MongoId' => array(
                 null, $mongoId1, $mongoId2, array($mongoId1, $mongoId2),
@@ -83,7 +83,7 @@ class DocumentAddToSetTest extends TestCase
                 'string2', 'string1', 'string2', array('string2', 'string1'),
             ),
             'scalarField_emptyStdclass' => array(
-                2, $stdClass, $stdClass, array(2, array()),
+                2, $stdClass, $stdClass, array(2, $stdClass),
             ),
             'scalarField_MongoId' => array(
                 2, $mongoId1, $mongoId2, array(2, $mongoId1, $mongoId2),
@@ -125,7 +125,7 @@ class DocumentAddToSetTest extends TestCase
                 array('string2', 'string4'), 'string1', 'string2', array('string2', 'string4', 'string1'),
             ),
             'setField_emptyStdclass' => array(
-                array(2, 4), $stdClass, $stdClass, array(2, 4, array()),
+                array(2, 4), $stdClass, $stdClass, array(2, 4, $stdClass),
             ),
             'setField_MongoId' => array(
                 array(2, 4), $mongoId1, $mongoId2, array(2, 4, $mongoId1, $mongoId2),


### PR DESCRIPTION
Hello,

I created a patch that adds the ability to save an empty object to the collection. 
This need arose due to the nature of my system. 
The save method in the class Document saves an empty object as an array. 
Playback example:
I have Model Car extended Document.
Create $car = new Car();
$car->set('human-id', 1)->save();
$car->update(["human-id" => 1], ['$set' =>["markets-data.1" => ["car" => 1]]]);
Data in DB: 
```
{
	"_id" : ObjectId(""),
	"markets-data" : {
		"1" : {"car": 1}
	},
	"human-id" : 1
}
```
$car->update(["human-id" => 1], ['$unset' =>["markets-data.1" => ["car" => 1]]]);
Data in DB: 
```
{
	"_id" : ObjectId(""),
	"markets-data" : {},
	"human-id" : 1
}
```
$car->save();
Data in DB: 
```
{
	"_id" : ObjectId(""),
	"markets-data" : array(),
	"human-id" : 1
}
```


Here is an example of how update works in the native view:
```
> db.vehicle.update({"human-id": 36}, {'markets-data': {}, "human-id": 36});
WriteResult({ "nMatched" : 1, "nUpserted" : 0, "nModified" : 1 })
> db.vehicle.find({"human-id": 36}, {'markets-data': 1, 'human-id': 1}).pretty();
{
	"_id" : ObjectId(""),
	"markets-data" : {},
	"human-id" : 36
}
```

How to use my patch:
Create $car = new Car();
$car->set('human-id', 1)->save()
Data in DB:
```
{
	"_id" : ObjectId(""),
	"human-id" : 1
}
```

$car->set('markets-data', new \stdClass)->save();
{
	"_id" : ObjectId(""),
	"markets-data" : {},
	"human-id" : 1
}
```